### PR TITLE
Adding the option of holding the Command key to add a point

### DIFF
--- a/web_modules/App/Foot.js
+++ b/web_modules/App/Foot.js
@@ -9,7 +9,7 @@ function Foot(props) {
                 </div>
 
                 <div className="ad-Help">
-                    <strong>Ctrl + Click</strong> to add a point
+                    <strong>Ctrl + Click</strong> or <strong>Command + Click</strong> (on Mac) to add a point
                 </div>
             </div>
 

--- a/web_modules/Builder/index.js
+++ b/web_modules/Builder/index.js
@@ -45,13 +45,13 @@ class Builder extends Component {
     }
 
     handleKeyDown = (e) => {
-        if (e.ctrlKey) {
+        if (e.ctrlKey || e.metaKey) {
             this.setState({ ctrl: true })
         }
     }
 
     handleKeyUp = (e) => {
-        if ( ! e.ctrlKey) {
+        if ( ! e.ctrlKey && ! e.metaKey) {
             this.setState({ ctrl: false })
         }
     }


### PR DESCRIPTION
Adding the option of holding the Command key on the Mac to add a point. Because Ctrl + click simulate right click.
